### PR TITLE
[pr] Serialize structs for svm-rollup module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5909,6 +5909,8 @@ name = "solana-compute-budget"
 version = "2.0.2"
 dependencies = [
  "rustc_version",
+ "serde",
+ "serde_derive",
  "solana-frozen-abi",
  "solana-sdk",
 ]

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -12,6 +12,8 @@ edition = { workspace = true }
 [dependencies]
 solana-frozen-abi = { workspace = true, optional = true }
 solana-sdk = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/compute-budget/src/compute_budget.rs
+++ b/compute-budget/src/compute_budget.rs
@@ -1,4 +1,5 @@
 use crate::compute_budget_processor::{self, ComputeBudgetLimits, DEFAULT_HEAP_COST};
+use serde::{Serialize, Deserialize};
 
 #[cfg(all(RUSTC_WITH_SPECIALIZATION, feature = "frozen-abi"))]
 impl ::solana_frozen_abi::abi_example::AbiExample for ComputeBudget {
@@ -18,7 +19,7 @@ pub const MAX_CALL_DEPTH: usize = 64;
 /// The size of one SBF stack frame.
 pub const STACK_FRAME_SIZE: usize = 4096;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ComputeBudget {
     /// Number of compute units that a transaction or individual instruction is
     /// allowed to consume. Compute units are consumed by program execution,

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -1069,7 +1069,7 @@ lazy_static! {
 
 /// `FeatureSet` holds the set of currently active/inactive runtime features
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct FeatureSet {
     pub active: HashMap<Pubkey, Slot>,
     pub inactive: HashSet<Pubkey>,

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -3,9 +3,10 @@
 use crate::native_token::sol_to_lamports;
 #[cfg(not(target_os = "solana"))]
 use solana_program::message::SanitizedMessage;
+use serde::{Serialize, Deserialize};
 
 /// A fee and its associated compute unit limit
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
 pub struct FeeBin {
     /// maximum compute units for which this fee will be charged
     pub limit: u64,
@@ -21,7 +22,7 @@ pub struct FeeBudgetLimits {
 }
 
 /// Information used to calculate fees
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct FeeStructure {
     /// lamports per signature
     pub lamports_per_signature: u64,


### PR DESCRIPTION
#### Problem
Some structs have to be Serializable to be included in SVM module in svm-rollup repository

#### Summary of Changes
Serialized ComputeBudget, FeatureSet, FeeStructure and FeeBin (which is within FeeStructure)

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
