### PR TITLE
[pr] serialize TransactionSimulationResult

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -358,6 +358,7 @@ pub struct LoadAndExecuteTransactionsOutput {
     pub error_counters: TransactionErrorMetrics,
 }
 
+#[derive(Serialize, Deserialize, Clone)]
 pub struct TransactionSimulationResult {
     pub result: Result<()>,
     pub logs: TransactionLogMessages,


### PR DESCRIPTION
#### Problem


#### Summary of Changes
Added serde serialization to TransactionSimulationResult struct, so it is usable in `simulate_transaction` rpc method in `svm-rollup`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
