### PR TITLE
Unthread bucket map holder

### DIFF
--- a/accounts-db/src/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index_storage.rs
@@ -64,30 +64,17 @@ impl BgThreads {
     ) -> Self {
         // stop signal used for THIS batch of bg threads
         let local_exit = Arc::new(AtomicBool::default());
-        let handles = Some(
-            (0..threads)
-                .map(|idx| {
-                    // the first thread we start is special
-                    let can_advance_age = can_advance_age && idx == 0;
-                    let storage_ = Arc::clone(storage);
-                    let local_exit = local_exit.clone();
-                    let system_exit = exit.clone();
-                    let in_mem_ = in_mem.to_vec();
 
-                    // note that using rayon here causes us to exhaust # rayon threads and many tests running in parallel deadlock
-                    Builder::new()
-                        .name(format!("solIdxFlusher{idx:02}"))
-                        .spawn(move || {
-                            storage_.background(
-                                vec![local_exit, system_exit],
-                                in_mem_,
-                                can_advance_age,
-                            );
-                        })
-                        .unwrap()
-                })
-                .collect(),
-        );
+        (0..threads)
+            .map(|idx| {
+                // the first thread we start is special
+                //                let can_advance_age = can_advance_age && idx == 0;
+                let storage_ = Arc::clone(storage);
+                //                let local_exit = local_exit.clone();
+                //                let system_exit = exit.clone();
+                let in_mem_ = in_mem.to_vec();
+                storage_.foreground(in_mem_);
+            });
 
         BgThreads {
             exit: local_exit,

--- a/accounts-db/src/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index_storage.rs
@@ -78,7 +78,7 @@ impl BgThreads {
 
         BgThreads {
             exit: local_exit,
-            handles,
+            handles: None,
             wait: Arc::clone(&storage.wait_dirty_or_aged),
         }
     }

--- a/accounts-db/src/accounts_index_storage.rs
+++ b/accounts-db/src/accounts_index_storage.rs
@@ -65,20 +65,43 @@ impl BgThreads {
         // stop signal used for THIS batch of bg threads
         let local_exit = Arc::new(AtomicBool::default());
 
-        (0..threads)
-            .map(|idx| {
-                // the first thread we start is special
-                //                let can_advance_age = can_advance_age && idx == 0;
+        let handles = if (cfg!(feature = "multithreaded")) {
+            Some(
+                (0..threads)
+                    .map(|idx| {
+                        // the first thread we start is special
+                        let can_advance_age = can_advance_age && idx == 0;
+                        let storage_ = Arc::clone(storage);
+                        let local_exit = local_exit.clone();
+                        let system_exit = exit.clone();
+                        let in_mem_ = in_mem.to_vec();
+
+                        // note that using rayon here causes us to exhaust # rayon threads and many tests running in parallel deadlock
+                        Builder::new()
+                            .name(format!("solIdxFlusher{idx:02}"))
+                            .spawn(move || {
+                                storage_.background(
+                                    vec![local_exit, system_exit],
+                                    in_mem_,
+                                    can_advance_age,
+                                );
+                            })
+                            .unwrap()
+                    })
+                    .collect(),
+            )
+        } else {
+            (0..threads).map(|idx| {
                 let storage_ = Arc::clone(storage);
-                //                let local_exit = local_exit.clone();
-                //                let system_exit = exit.clone();
                 let in_mem_ = in_mem.to_vec();
                 storage_.foreground(in_mem_);
             });
+            None
+        };
 
         BgThreads {
             exit: local_exit,
-            handles: None,
+            handles,
             wait: Arc::clone(&storage.wait_dirty_or_aged),
         }
     }

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -434,6 +434,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         }
     }
 }
+
 #[cfg(test)]
 pub mod tests {
     use {super::*, rayon::prelude::*, std::time::Instant};

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -74,7 +74,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     _phantom: PhantomData<T>,
 
     // Used by the foreground function, maybe not needed at all
-    can_advance_age: bool;
+    can_advance_age: bool,
 
     pub(crate) startup_stats: Arc<StartupStats>,
 }

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -415,14 +415,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         }
     }
 
-    pub fn foreground(
-        &self,
-        in_mem: Vec<Arc<InMemAccountsIndex<T, U>>>,
-    ) {
+    pub fn foreground(&self, in_mem: Vec<Arc<InMemAccountsIndex<T, U>>>) {
         let bins = in_mem.len();
         let flush = self.disk.is_some();
 
-        if !flush { return; }
+        if !flush {
+            return;
+        }
 
         for _ in 0..bins {
             let index = self.next_bucket_to_flush();

--- a/accounts-db/src/bucket_map_holder.rs
+++ b/accounts-db/src/bucket_map_holder.rs
@@ -414,7 +414,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             self.stats.active_threads.fetch_sub(1, Ordering::Relaxed);
         }
     }
-}
 
     pub fn foreground(
         &self,

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -89,7 +89,7 @@ pub(crate) struct ReadOnlyAccountsCache {
     // To the evictor goes the spoiled [sic]
     //
     // Evict from the cache in the background.
-    #[cfg(feature = "multithreaded")]
+    #[cfg(not(target_os = "zkvm"))]
     _evictor: thread::JoinHandle<()>,
 }
 
@@ -105,7 +105,7 @@ impl ReadOnlyAccountsCache {
         let data_size = Arc::new(AtomicUsize::default());
         let stats = Arc::new(AtomicReadOnlyCacheStats::default());
         let (evict_sender, evict_receiver) = crossbeam_channel::bounded::<()>(1);
-        #[cfg(feature = "multithreaded")]
+        #[cfg(not(target_os = "zkvm"))]
         let evictor = Self::spawn_evictor(
             evict_receiver,
             max_data_size_lo,
@@ -126,7 +126,7 @@ impl ReadOnlyAccountsCache {
             ms_to_skip_lru_update,
             stats,
             evict_sender,
-            #[cfg(feature = "multithreaded")]
+            #[cfg(not(target_os = "zkvm"))]
             _evictor: evictor,
         }
     }
@@ -205,7 +205,7 @@ impl ReadOnlyAccountsCache {
             }
         };
 
-        #[cfg(feature = "multithreaded")]
+        #[cfg(not(target_os = "zkvm"))]
         if self.data_size() > self.max_data_size_hi {
             self.send_evict();
         }

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -86,10 +86,10 @@ pub(crate) struct ReadOnlyAccountsCache {
     ///
     /// NOTE: This field must be above `evictor` to ensure it is dropped before `evictor`.
     evict_sender: crossbeam_channel::Sender<()>,
-    /// To the evictor goes the spoiled [sic]
-    ///
-    /// Evict from the cache in the background.
-    _evictor: thread::JoinHandle<()>,
+    // To the evictor goes the spoiled [sic]
+    //
+    // Evict from the cache in the background.
+    //_evictor: thread::JoinHandle<()>,
 }
 
 impl ReadOnlyAccountsCache {
@@ -104,15 +104,15 @@ impl ReadOnlyAccountsCache {
         let data_size = Arc::new(AtomicUsize::default());
         let stats = Arc::new(AtomicReadOnlyCacheStats::default());
         let (evict_sender, evict_receiver) = crossbeam_channel::bounded::<()>(1);
-        let evictor = Self::spawn_evictor(
-            evict_receiver,
-            max_data_size_lo,
-            max_data_size_hi,
-            data_size.clone(),
-            cache.clone(),
-            queue.clone(),
-            stats.clone(),
-        );
+        // let evictor = Self::spawn_evictor(
+        //     evict_receiver,
+        //     max_data_size_lo,
+        //     max_data_size_hi,
+        //     data_size.clone(),
+        //     cache.clone(),
+        //     queue.clone(),
+        //     stats.clone(),
+        // );
 
         Self {
             highest_slot_stored: AtomicU64::default(),
@@ -124,7 +124,7 @@ impl ReadOnlyAccountsCache {
             ms_to_skip_lru_update,
             stats,
             evict_sender,
-            _evictor: evictor,
+//            _evictor: evictor,
         }
     }
 
@@ -202,9 +202,9 @@ impl ReadOnlyAccountsCache {
             }
         };
 
-        if self.data_size() > self.max_data_size_hi {
-            self.send_evict();
-        }
+        // if self.data_size() > self.max_data_size_hi {
+        //     self.send_evict();
+        // }
         let store_us = measure_store.end_as_us();
         self.stats.store_us.fetch_add(store_us, Ordering::Relaxed);
     }


### PR DESCRIPTION
Remove use of background threads from BucketMapHolder and the read-only accounts cache.

The sync versions of these tools will have to be called occasionally in the future, but we'll figure that out when we get to it.
