### PR TITLE
[pr] Serialize Keypair

### DIFF
--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -28,6 +28,7 @@ use {
 #[derive(Debug)]
 pub struct Keypair(ed25519_dalek::Keypair);
 
+// Implement Clone for Keypair
 impl Clone for Keypair {
     fn clone(&self) -> Self {
         let bytes = self.0.to_bytes();
@@ -54,7 +55,7 @@ impl BorshDeserialize for Keypair {
     }
 }
 
-// Implement Serde Serialization and Deserialization
+// Implement Serde Serialization and Deserialization for Keypair
 impl Serialize for Keypair {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_bytes(self.0.to_bytes().as_ref())


### PR DESCRIPTION
#### Problem
In this [pr](https://github.com/nitro-svm/svm-rollup/pull/89) could not create new field in `CallMessage` enum because of trait boundaries for Clone, Borsh and serde.

#### Summary of Changes
Implemented Clone, Borsh and serde for `Keypair` for the sake of this [pr](https://github.com/nitro-svm/svm-rollup/pull/89)


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
