### PR TITLE
Added VmSlice class, a slice in the virtual address space.

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -511,7 +511,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
     ) -> Result<Vec<Pubkey>, Error> {
         let mut signers = Vec::new();
         if signers_seeds_len > 0 {
-            let signers_seeds = translate_slice::<&[&[u8]]>(
+            let signers_seeds = translate_slice_of_slices::<VmSlice<u8>>(
                 memory_mapping,
                 signers_seeds_addr,
                 signers_seeds_len,
@@ -521,10 +521,10 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
                 return Err(Box::new(SyscallError::TooManySigners));
             }
             for signer_seeds in signers_seeds.iter() {
-                let untranslated_seeds = translate_slice::<&[u8]>(
+                let untranslated_seeds = translate_slice_of_slices::<u8>(
                     memory_mapping,
-                    signer_seeds.as_ptr() as *const _ as u64,
-                    signer_seeds.len() as u64,
+                    signer_seeds.ptr(),
+                    signer_seeds.len(),
                     invoke_context.get_check_aligned(),
                 )?;
                 if untranslated_seeds.len() > MAX_SEEDS {
@@ -533,12 +533,8 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
                 let seeds = untranslated_seeds
                     .iter()
                     .map(|untranslated_seed| {
-                        translate_slice::<u8>(
-                            memory_mapping,
-                            untranslated_seed.as_ptr() as *const _ as u64,
-                            untranslated_seed.len() as u64,
-                            invoke_context.get_check_aligned(),
-                        )
+                        untranslated_seed
+                            .translate(memory_mapping, invoke_context.get_check_aligned())
                     })
                     .collect::<Result<Vec<_>, Error>>()?;
                 let signer = Pubkey::create_program_address(&seeds, program_id)

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -228,13 +228,6 @@ impl HasherImpl for Keccak256Hasher {
     }
 }
 
-pub struct VmSlice<'a, T> {
-    memory_mapping: &'a MemoryMapping<'a>,
-    ptr: u64,
-    len: u64,
-    resource_type: PhantomData<T>,
-}
-
 // The VmSlice class is used for cases when you need a slice that is stored in the BPF
 // interpreter's virtual address space. Because this source code can be compiled with
 // addresses of different bit depths, we cannot assume that the 64-bit BPF interpreter's
@@ -243,23 +236,42 @@ pub struct VmSlice<'a, T> {
 // 32-bit app build than in the 64-bit virtual space. Therefore instead of a slice-of-slices,
 // you should implement a slice-of-VmSlices, which can then use VmSlice::translate() to
 // map to the physical address.
-impl<'a, T> VmSlice<'a, T> {
-    pub fn new(memory_mapping: &'a MemoryMapping, ptr: u64, len: u64) -> Self {
+// This class must consist only of 16 bytes: a u64 ptr and a u64 len, to match the 64-bit
+// implementation of a slice in Rust. The PhantomData entry takes up 0 bytes.
+pub struct VmSlice<T> {
+    ptr: u64,
+    len: u64,
+    resource_type: PhantomData<T>,
+}
+
+impl<T> VmSlice<T> {
+    pub fn new(ptr: u64, len: u64) -> Self {
         VmSlice {
-            memory_mapping,
             ptr,
             len,
             resource_type: PhantomData,
         }
     }
 
-    /// Returns a slice using a mapped physical address
-    pub fn translate(&self) -> Result<&'a [T], Error> {
-        translate_slice::<T>(self.memory_mapping, self.ptr, self.len, false)
+    pub fn len(&self) -> u64 {
+        self.len
     }
 
-    pub fn translate_mut(&mut self) -> Result<&'a mut [T], Error> {
-        translate_slice_mut::<T>(self.memory_mapping, self.ptr, self.len, false)
+    /// Returns a slice using a mapped physical address
+    pub fn translate(
+        &self,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<&[T], Error> {
+        translate_slice::<T>(memory_mapping, self.ptr, self.len, check_aligned)
+    }
+
+    pub fn translate_mut(
+        &mut self,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<&mut [T], Error> {
+        translate_slice_mut::<T>(memory_mapping, self.ptr, self.len, check_aligned)
     }
 }
 
@@ -655,6 +667,61 @@ fn translate_slice<'a, T>(
     .map(|value| &*value)
 }
 
+fn translate_slice_of_slices_inner<'a, T>(
+    memory_mapping: &MemoryMapping,
+    access_type: AccessType,
+    vm_addr: u64,
+    len: u64,
+    check_aligned: bool,
+) -> Result<&'a mut [VmSlice<T>], Error> {
+    if len == 0 {
+        return Ok(&mut []);
+    }
+
+    let total_size = len.saturating_mul(size_of::<VmSlice<T>>() as u64);
+    if isize::try_from(total_size).is_err() {
+        return Err(SyscallError::InvalidLength.into());
+    }
+
+    let host_addr = translate(memory_mapping, access_type, vm_addr, total_size)?;
+
+    if check_aligned && !address_is_aligned::<VmSlice<T>>(host_addr) {
+        return Err(SyscallError::UnalignedPointer.into());
+    }
+    Ok(unsafe { from_raw_parts_mut(host_addr as *mut VmSlice<T>, len as usize) })
+}
+
+fn translate_slice_of_slices_mut<'a, T>(
+    memory_mapping: &MemoryMapping,
+    vm_addr: u64,
+    len: u64,
+    check_aligned: bool,
+) -> Result<&'a mut [VmSlice<T>], Error> {
+    translate_slice_of_slices_inner::<T>(
+        memory_mapping,
+        AccessType::Store,
+        vm_addr,
+        len,
+        check_aligned,
+    )
+}
+
+fn translate_slice_of_slices<'a, T>(
+    memory_mapping: &MemoryMapping,
+    vm_addr: u64,
+    len: u64,
+    check_aligned: bool,
+) -> Result<&'a [VmSlice<T>], Error> {
+    translate_slice_of_slices_inner::<T>(
+        memory_mapping,
+        AccessType::Load,
+        vm_addr,
+        len,
+        check_aligned,
+    )
+    .map(|value| &*value)
+}
+
 /// Take a virtual pointer to a string (points to SBF VM memory space), translate it
 /// pass it to a user-defined work function
 fn translate_string_and_do(
@@ -761,22 +828,17 @@ fn translate_and_check_program_address_inputs<'a>(
     check_aligned: bool,
 ) -> Result<(Vec<&'a [u8]>, &'a Pubkey), Error> {
     let untranslated_seeds =
-        translate_slice::<&[u8]>(memory_mapping, seeds_addr, seeds_len, check_aligned)?;
+        translate_slice_of_slices::<u8>(memory_mapping, seeds_addr, seeds_len, check_aligned)?;
     if untranslated_seeds.len() > MAX_SEEDS {
         return Err(SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded).into());
     }
     let seeds = untranslated_seeds
         .iter()
         .map(|untranslated_seed| {
-            if untranslated_seed.len() > MAX_SEED_LEN {
+            if untranslated_seed.len() > MAX_SEED_LEN as u64 {
                 return Err(SyscallError::BadSeeds(PubkeyError::MaxSeedLengthExceeded).into());
             }
-            translate_slice::<u8>(
-                memory_mapping,
-                untranslated_seed.as_ptr() as *const _ as u64,
-                untranslated_seed.len() as u64,
-                check_aligned,
-            )
+            untranslated_seed.translate(memory_mapping, check_aligned)
         })
         .collect::<Result<Vec<_>, Error>>()?;
     let program_id = translate_type::<Pubkey>(memory_mapping, program_id_addr, check_aligned)?;

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -235,6 +235,14 @@ pub struct VmSlice<'a, T> {
     resource_type: PhantomData<T>,
 }
 
+// The VmSlice class is used for cases when you need a slice that is stored in the BPF
+// interpreter's virtual address space. Because this source code can be compiled with
+// addresses of different bit depths, we cannot assume that the 64-bit BPF interpreter's
+// pointer sizes can be mapped to physical pointer sizes. In particular, if you need a
+// slice-of-slices in the virtual space, the inner slices will be different sizes in a
+// 32-bit app build than in the 64-bit virtual space. Therefore instead of a slice-of-slices,
+// you should implement a slice-of-VmSlices, which can then use VmSlice::translate() to
+// map to the physical address.
 impl<'a, T> VmSlice<'a, T> {
     pub fn new(memory_mapping: &'a MemoryMapping, ptr: u64, len: u64) -> Self {
         VmSlice {

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -260,6 +260,16 @@ impl<T> VmSlice<T> {
         self.len
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Adjust the length of the vector. This is unchecked, and it assumes that the pointer
+    /// points to valid memory of the correct length after vm-translation.
+    pub fn resize(&mut self, len: u64) {
+        self.len = len;
+    }
+
     /// Returns a slice using a mapped physical address
     pub fn translate(
         &self,
@@ -694,6 +704,7 @@ fn translate_slice_of_slices_inner<'a, T>(
     Ok(unsafe { from_raw_parts_mut(host_addr as *mut VmSlice<T>, len as usize) })
 }
 
+#[allow(dead_code)]
 fn translate_slice_of_slices_mut<'a, T>(
     memory_mapping: &MemoryMapping,
     vm_addr: u64,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -253,7 +253,7 @@ impl<'a, T> VmSlice<'a, T> {
         }
     }
 
-    // Returns a slice using a mapped physical address
+    /// Returns a slice using a mapped physical address
     pub fn translate(&self) -> Result<&'a [T], Error> {
         translate_slice::<T>(self.memory_mapping, self.ptr, self.len, false)
     }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -226,6 +226,47 @@ impl HasherImpl for Keccak256Hasher {
     }
 }
 
+pub struct VmSlice<'a, T> {
+    memory_mapping: &'a MemoryMapping<'a>,
+    ptr: u64,
+    len: u64,
+}
+
+impl<'a, T> VmSlice<'a, T> {
+    pub fn new<'a, T>(memory_mapping: &'a MemoryMapping, ptr: u64, len: u64) -> Self {
+        VmSlice { memory_mapping, ptr, len }
+    }
+
+    // Returns a slice using a mapped physical address
+    pub fn translate<'a, T>(
+        &self
+    ) -> Result<&'a [T], Error> {
+        translate_slice(self.memory_mapping, self.ptr, self.len, false)
+    }
+
+    pub fn translate_mut<'a, T>(
+        &mut self,
+    ) -> Result<&'a mut [T], Error> {
+        translate_slice_mut(self.memory_mapping, self.ptr, self.len, false)
+    }
+}
+
+impl<'a, T> Iterator for VmSlice<'a, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len > 0 {
+            let res = translate_type(self.memory_mapping, self.ptr, false).ok();
+            self.ptr.saturating_add(size_of::<T>());
+            self.len.saturating_sub(1);
+            res
+        }
+        else {
+            None
+        }
+    }
+}
+
 fn consume_compute_meter(invoke_context: &InvokeContext, amount: u64) -> Result<(), Error> {
     invoke_context.consume_checked(amount)?;
     Ok(())


### PR DESCRIPTION
#### Problem

Add a new VmSlice class, to support slices that are in VM-space. This is needed for keys (or anything else) that are implemented as slices-of-slices. The "inner" slice is in VM-space, but the existing code treats it as if it were a physical address by using a "real" Rust slice for it. This works okay as long as the Agave code is compiled with 64-bit addresses, which matches the 64-bit VM address space. However, if the code is built in 32 bits, interpreted programs can fail with bad memory accesses.

#### Summary of Changes

Addition of VmSlice class: a virtual-space slice.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
