### PR TITLE
Converted StableVec to use u64 virtual addresses rather than physical

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -336,7 +336,7 @@ impl<'a> InvokeContext<'a> {
         // but performed on a very small slice and requires no heap allocations.
         let instruction_context = self.transaction_context.get_current_instruction_context()?;
         let mut deduplicated_instruction_accounts: Vec<InstructionAccount> = Vec::new();
-        let mut duplicate_indicies = Vec::with_capacity(instruction.accounts.len());
+        let mut duplicate_indicies = Vec::with_capacity(instruction.accounts.len() as usize);
         for (instruction_account_index, account_meta) in instruction.accounts.iter().enumerate() {
             let index_in_transaction = self
                 .transaction_context

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -424,14 +424,14 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         )?;
         let account_metas = translate_slice::<AccountMeta>(
             memory_mapping,
-            ix.accounts.as_ptr() as u64,
-            ix.accounts.len() as u64,
+            ix.accounts.as_vaddr(),
+            ix.accounts.len(),
             invoke_context.get_check_aligned(),
         )?;
         let data = translate_slice::<u8>(
             memory_mapping,
-            ix.data.as_ptr() as u64,
-            ix.data.len() as u64,
+            ix.data.as_vaddr(),
+            ix.data.len(),
             invoke_context.get_check_aligned(),
         )?
         .to_vec();

--- a/sdk/stable-layout/src/stable_vec.rs
+++ b/sdk/stable-layout/src/stable_vec.rs
@@ -1,7 +1,10 @@
 //! `Vec`, with a stable memory layout
 
-use std::ops::{Deref, DerefMut};
-use std::{marker::PhantomData, mem::ManuallyDrop};
+use std::{
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+};
 
 /// `Vec`, with a stable memory layout
 ///

--- a/sdk/stable-layout/src/stable_vec.rs
+++ b/sdk/stable-layout/src/stable_vec.rs
@@ -1,6 +1,7 @@
 //! `Vec`, with a stable memory layout
 
-use std::{marker::PhantomData, mem::ManuallyDrop, ptr::NonNull};
+use std::ops::{Deref, DerefMut};
+use std::{marker::PhantomData, mem::ManuallyDrop};
 
 /// `Vec`, with a stable memory layout
 ///
@@ -24,9 +25,9 @@ use std::{marker::PhantomData, mem::ManuallyDrop, ptr::NonNull};
 /// ```
 #[repr(C)]
 pub struct StableVec<T> {
-    pub ptr: NonNull<T>,
-    pub cap: usize,
-    pub len: usize,
+    pub addr: u64,
+    pub cap: u64,
+    pub len: u64,
     _marker: PhantomData<T>,
 }
 
@@ -34,17 +35,12 @@ pub struct StableVec<T> {
 // `deref`, which creates an intermediate reference.
 impl<T> StableVec<T> {
     #[inline]
-    pub fn as_ptr(&self) -> *const T {
-        self.ptr.as_ptr()
+    pub fn as_vaddr(&self) -> u64 {
+        self.addr
     }
 
     #[inline]
-    pub fn as_mut_ptr(&mut self) -> *mut T {
-        self.ptr.as_ptr()
-    }
-
-    #[inline]
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u64 {
         self.len
     }
 
@@ -56,13 +52,13 @@ impl<T> StableVec<T> {
 
 impl<T> AsRef<[T]> for StableVec<T> {
     fn as_ref(&self) -> &[T] {
-        self
-    }
+        self.deref()
+    } // === is this right?
 }
 
 impl<T> AsMut<[T]> for StableVec<T> {
     fn as_mut(&mut self) -> &mut [T] {
-        self
+        self.deref_mut()
     }
 }
 
@@ -71,14 +67,14 @@ impl<T> std::ops::Deref for StableVec<T> {
 
     #[inline]
     fn deref(&self) -> &[T] {
-        unsafe { core::slice::from_raw_parts(self.as_ptr(), self.len) }
+        unsafe { core::slice::from_raw_parts(self.addr as usize as *mut T, self.len as usize) }
     }
 }
 
 impl<T> std::ops::DerefMut for StableVec<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut [T] {
-        unsafe { core::slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
+        unsafe { core::slice::from_raw_parts_mut(self.addr as usize as *mut T, self.len as usize) }
     }
 }
 
@@ -121,9 +117,9 @@ impl<T> From<Vec<T>> for StableVec<T> {
         let mut other = ManuallyDrop::new(other);
         Self {
             // SAFETY: We have a valid Vec, so its ptr is non-null.
-            ptr: unsafe { NonNull::new_unchecked(other.as_mut_ptr()) },
-            cap: other.capacity(),
-            len: other.len(),
+            addr: other.as_mut_ptr() as u64, // Problematic if other is in 32-bit physical address space
+            cap: other.capacity() as u64,
+            len: other.len() as u64,
             _marker: PhantomData,
         }
     }
@@ -135,8 +131,16 @@ impl<T> From<StableVec<T>> for Vec<T> {
         // out of scope.
         let other = ManuallyDrop::new(other);
         // SAFETY: We have a valid StableVec, which we can only get from a Vec.  Therefore it is
-        // safe to convert back to Vec.
-        unsafe { Vec::from_raw_parts(other.ptr.as_ptr(), other.len, other.cap) }
+        // safe to convert back to Vec. Assuming we're not starting with a vector in 64-bit virtual
+        // address space while building the app in 32-bit, and this vector is in that 32-bit physical
+        // space.
+        unsafe {
+            Vec::from_raw_parts(
+                other.addr as usize as *mut T,
+                other.len as usize,
+                other.cap as usize,
+            )
+        }
     }
 }
 
@@ -147,7 +151,13 @@ impl<T> Drop for StableVec<T> {
         //
         // SAFETY: We have a valid StableVec, which we can only get from a Vec.  Therefore it is
         // safe to convert back to Vec.
-        let _vec = unsafe { Vec::from_raw_parts(self.ptr.as_ptr(), self.len, self.cap) };
+        let _vec = unsafe {
+            Vec::from_raw_parts(
+                self.addr as usize as *mut T,
+                self.len as usize,
+                self.cap as usize,
+            )
+        };
     }
 }
 

--- a/sdk/stable-layout/src/stable_vec.rs
+++ b/sdk/stable-layout/src/stable_vec.rs
@@ -53,7 +53,7 @@ impl<T> StableVec<T> {
 impl<T> AsRef<[T]> for StableVec<T> {
     fn as_ref(&self) -> &[T] {
         self.deref()
-    } // === is this right?
+    }
 }
 
 impl<T> AsMut<[T]> for StableVec<T> {


### PR DESCRIPTION
#### Problem
To address a 32-bit build issue, where cross-platform invocation fails due to bad virtual addressing, I have updated the StableVec class to use u64 for values, rather than a NonNull pointer class. There could be some issues if StableVecs are used indiscriminately to convert Vectors back and forth between virtual addressing and physical addressing (on a 32-bit build), but that's an issue of how it's used, not what it does.

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
