### PR TITLE
Remove writable-virtual-memory check in cpi when result will be ignored

### DIFF
--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -180,17 +180,10 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
             }
 
             // Translate the vmSlice into a physically addressed "true" Rust slice
-            let data_slice = if direct_mapping {
-                // we don't actually reference the data
-                ptr_box.value.translate_unchecked_mut(
-                    memory_mapping,
-                    invoke_context.get_check_aligned(),
-                )?
-            } else {
-                ptr_box
-                    .value
-                    .translate_mut(memory_mapping, invoke_context.get_check_aligned())?
-            };
+            let data_slice = ptr_box
+                .value
+                .translate(memory_mapping, invoke_context.get_check_aligned())?;
+
             consume_compute_meter(
                 invoke_context,
                 (data_slice.len() as u64)
@@ -241,7 +234,9 @@ impl<'a, 'b> CallerAccount<'a, 'b> {
                 // _yet_, but we will be able to once the caller returns.
                 &mut []
             } else {
-                data_slice
+                ptr_box
+                    .value
+                    .translate_mut(memory_mapping, invoke_context.get_check_aligned())?
             };
             (serialized_data, vm_data_addr, ref_to_len_in_vm)
         };

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -11,7 +11,6 @@ pub use self::{
     },
 };
 
-use solana_sdk::clock::Epoch;
 #[allow(deprecated)]
 use {
     solana_compute_budget::compute_budget::ComputeBudget,
@@ -70,6 +69,7 @@ use {
     },
     thiserror::Error as ThisError,
 };
+use solana_sdk::clock::Epoch;
 
 mod cpi;
 mod logging;
@@ -291,29 +291,22 @@ impl<T> VmSlice<T> {
     ) -> Result<&mut [T], Error> {
         translate_slice_mut::<T>(memory_mapping, self.ptr, self.len, check_aligned)
     }
-
-    // Does not confirm write access is allowed, but otherwise identical to translate_mut()
-    pub fn translate_unchecked_mut(
-        &mut self,
-        memory_mapping: &MemoryMapping,
-        check_aligned: bool,
-    ) -> Result<&mut [T], Error> {
-        translate_slice_unchecked_mut::<T>(memory_mapping, self.ptr, self.len, check_aligned)
-    }
 }
 
 // Structs to allow the AccountInfo translation to properly reference elements within
 // the 64-bit virtual address space even when built in 32-bit mode.
 #[derive(Clone)]
 #[repr(C)]
-pub struct VmNonNull<T> {
+pub struct VmNonNull<T>
+{
     pub addr: u64,
     resource_type: PhantomData<T>,
 }
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct VmBoxOfRefCell<T> {
+pub struct VmBoxOfRefCell<T>
+{
     _strong_addr: u64,
     _weak_addr: u64,
     _borrow_flag: u64,
@@ -695,21 +688,6 @@ fn translate_slice_mut<'a, T>(
     translate_slice_inner::<T>(
         memory_mapping,
         AccessType::Store,
-        vm_addr,
-        len,
-        check_aligned,
-    )
-}
-// Does not confirm write access is allowed, but otherwise identical to translate_slice_mut()
-fn translate_slice_unchecked_mut<'a, T>(
-    memory_mapping: &MemoryMapping,
-    vm_addr: u64,
-    len: u64,
-    check_aligned: bool,
-) -> Result<&'a mut [T], Error> {
-    translate_slice_inner::<T>(
-        memory_mapping,
-        AccessType::Load,
         vm_addr,
         len,
         check_aligned,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -11,6 +11,7 @@ pub use self::{
     },
 };
 
+use solana_sdk::clock::Epoch;
 #[allow(deprecated)]
 use {
     solana_compute_budget::compute_budget::ComputeBudget,
@@ -69,7 +70,6 @@ use {
     },
     thiserror::Error as ThisError,
 };
-use solana_sdk::clock::Epoch;
 
 mod cpi;
 mod logging;
@@ -291,22 +291,29 @@ impl<T> VmSlice<T> {
     ) -> Result<&mut [T], Error> {
         translate_slice_mut::<T>(memory_mapping, self.ptr, self.len, check_aligned)
     }
+
+    // Does not confirm write access is allowed, but otherwise identical to translate_mut()
+    pub fn translate_unchecked_mut(
+        &mut self,
+        memory_mapping: &MemoryMapping,
+        check_aligned: bool,
+    ) -> Result<&mut [T], Error> {
+        translate_slice_unchecked_mut::<T>(memory_mapping, self.ptr, self.len, check_aligned)
+    }
 }
 
 // Structs to allow the AccountInfo translation to properly reference elements within
 // the 64-bit virtual address space even when built in 32-bit mode.
 #[derive(Clone)]
 #[repr(C)]
-pub struct VmNonNull<T>
-{
+pub struct VmNonNull<T> {
     pub addr: u64,
     resource_type: PhantomData<T>,
 }
 
 #[derive(Clone)]
 #[repr(C)]
-pub struct VmBoxOfRefCell<T>
-{
+pub struct VmBoxOfRefCell<T> {
     _strong_addr: u64,
     _weak_addr: u64,
     _borrow_flag: u64,
@@ -688,6 +695,21 @@ fn translate_slice_mut<'a, T>(
     translate_slice_inner::<T>(
         memory_mapping,
         AccessType::Store,
+        vm_addr,
+        len,
+        check_aligned,
+    )
+}
+// Does not confirm write access is allowed, but otherwise identical to translate_slice_mut()
+fn translate_slice_unchecked_mut<'a, T>(
+    memory_mapping: &MemoryMapping,
+    vm_addr: u64,
+    len: u64,
+    check_aligned: bool,
+) -> Result<&'a mut [T], Error> {
+    translate_slice_inner::<T>(
+        memory_mapping,
+        AccessType::Load,
         vm_addr,
         len,
         check_aligned,


### PR DESCRIPTION
…but can still fail the check. This is an issue with the direct_memory flag sometimes needing access to writable memory when it doesn't know it's writable yet (see comment inside CallerAccount::from_vm_account_info()).

Also ran rustfmt on it.

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
