### PR TITLE
chore: Remove `Base64Zstd` usage from `rpc-client`

### DIFF
--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -3417,7 +3417,8 @@ impl RpcClient {
         commitment_config: CommitmentConfig,
     ) -> RpcResult<Option<Account>> {
         let config = RpcAccountInfoConfig {
-            encoding: Some(UiAccountEncoding::Base64Zstd),
+            // encoding: Some(UiAccountEncoding::Base64Zstd), Zstd is not supported by svm-rollup
+            encoding: Some(UiAccountEncoding::Base64),
             commitment: Some(commitment_config),
             data_slice: None,
             min_context_slot: None,
@@ -3644,7 +3645,8 @@ impl RpcClient {
         self.get_multiple_accounts_with_config(
             pubkeys,
             RpcAccountInfoConfig {
-                encoding: Some(UiAccountEncoding::Base64Zstd),
+                // encoding: Some(UiAccountEncoding::Base64Zstd), Zstd is not supported by svm-rollup
+                encoding: Some(UiAccountEncoding::Base64),
                 commitment: Some(commitment_config),
                 data_slice: None,
                 min_context_slot: None,
@@ -3917,7 +3919,8 @@ impl RpcClient {
             pubkey,
             RpcProgramAccountsConfig {
                 account_config: RpcAccountInfoConfig {
-                    encoding: Some(UiAccountEncoding::Base64Zstd),
+                    // encoding: Some(UiAccountEncoding::Base64Zstd), Zstd is not supported by svm-rollup
+                    encoding: Some(UiAccountEncoding::Base64),
                     ..RpcAccountInfoConfig::default()
                 },
                 ..RpcProgramAccountsConfig::default()


### PR DESCRIPTION
#### Problem

This fixes issues when building the indexer in our [nitro-da](https://github.com/nitro-svm/nitro-da) repository.
More specificaly, this change is needed because we were not using the `solana-rpc-client` crate and thus not hitting this error, but it is something we need to use going forward.