### PR TITLE
fix: Update memory-map of an AccountInfo struct to a VmAccountInfo

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   check:
-    if: github.repository == 'anza-xyz/agave'
+#    if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -77,7 +77,7 @@ jobs:
           cargo check
 
   test_cli:
-    if: github.repository == 'anza-xyz/agave'
+#    if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -108,7 +108,7 @@ jobs:
           cargo test --manifest-path clients/cli/Cargo.toml
 
   cargo-test-sbf:
-    if: github.repository == 'anza-xyz/agave'
+#    if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7699,6 +7699,7 @@ dependencies = [
  "solana-nonce",
  "solana-nonce-account",
  "solana-packet",
+ "solana-patches",
  "solana-perf",
  "solana-poh",
  "solana-poh-config",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -119,6 +119,7 @@ solana-net-utils = { workspace = true }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true }
 solana-packet = { workspace = true }
+solana-patches = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }
 solana-poh-config = { workspace = true }

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -210,23 +210,6 @@ impl QosService {
                         CommitTransactionDetails::NotCommitted => {
                             cost_tracker.remove(tx_cost);
                         }
-                    match transaction_committed_details {
-                        CommitTransactionDetails::Committed {
-                            compute_units,
-                            loaded_accounts_data_size,
-                        } => {
-                            cost_tracker.update_execution_cost(
-                                tx_cost,
-                                *compute_units,
-                                CostModel::calculate_loaded_accounts_data_size_cost(
-                                    *loaded_accounts_data_size,
-                                    &bank.feature_set,
-                                ),
-                            );
-                        }
-                        CommitTransactionDetails::NotCommitted => {
-                            cost_tracker.remove(tx_cost);
-                        }
                     }
                 }
             });

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -172,7 +172,6 @@ mod tests {
     }
 
     fn create_test_bank() -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
-    fn create_test_bank() -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         Bank::new_no_wallclock_throttle_for_tests(&genesis_config)
     }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2005,17 +2005,17 @@ fn main() {
                     let snapshot_archive_format = {
                         let archive_format_str =
                             value_t_or_exit!(arg_matches, "snapshot_archive_format", String);
-                        let mut archive_format = ArchiveFormat::from_cli_arg(&archive_format_str)
+                        let archive_format = ArchiveFormat::from_cli_arg(&archive_format_str)
                             .unwrap_or_else(|| {
                                 panic!("Archive format not recognized: {archive_format_str}")
                             });
-                        if let ArchiveFormat::TarZstd { config } = &mut archive_format {
-                            config.compression_level = value_t_or_exit!(
-                                arg_matches,
-                                "snapshot_zstd_compression_level",
-                                i32
-                            );
-                        }
+                        // if let ArchiveFormat::TarZstd { config } = &mut archive_format {
+                        //     config.compression_level = value_t_or_exit!(
+                        //         arg_matches,
+                        //         "snapshot_zstd_compression_level",
+                        //         i32
+                        //     );
+                        // }
                         archive_format
                     };
 

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -124,22 +124,6 @@ impl Display for SlotBankHash {
     }
 }
 
-#[derive(Serialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct SlotBankHash {
-    pub slot: Slot,
-    pub hash: String,
-}
-
-impl VerboseDisplay for SlotBankHash {}
-impl QuietDisplay for SlotBankHash {}
-
-impl Display for SlotBankHash {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        writeln!(f, "Bank hash for slot {}: {}", self.slot, self.hash)
-    }
-}
-
 fn writeln_entry(f: &mut dyn fmt::Write, i: usize, entry: &CliEntry, prefix: &str) -> fmt::Result {
     writeln!(
         f,

--- a/precompiles/src/secp256k1.rs
+++ b/precompiles/src/secp256k1.rs
@@ -3,7 +3,7 @@ use {
     digest::Digest,
     solana_precompile_error::PrecompileError,
     solana_secp256k1_program::{
-        construct_eth_pubkey, SecpSignatureOffsets, HASHED_PUBKEY_SERIALIZED_SIZE,
+        eth_address_from_pubkey, SecpSignatureOffsets, HASHED_PUBKEY_SERIALIZED_SIZE,
         SIGNATURE_OFFSETS_SERIALIZED_SIZE, SIGNATURE_SERIALIZED_SIZE,
     },
 };
@@ -97,7 +97,7 @@ pub fn verify(
             &recovery_id,
         )
         .map_err(|_| PrecompileError::InvalidSignature)?;
-        let eth_address = construct_eth_pubkey(&pubkey);
+        let eth_address = eth_address_from_pubkey(&pubkey.serialize()[1..].try_into().unwrap());
 
         if eth_address_slice != eth_address {
             return Err(PrecompileError::InvalidSignature);
@@ -334,7 +334,7 @@ pub mod tests {
 
         let secret_key = libsecp256k1::SecretKey::random(&mut thread_rng());
         let public_key = libsecp256k1::PublicKey::from_secret_key(&secret_key);
-        let eth_address = construct_eth_pubkey(&public_key);
+        let eth_address = eth_address_from_pubkey(&public_key.serialize()[1..].try_into().unwrap());
 
         let message = b"hello";
         let message_hash = {

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -2930,33 +2930,28 @@ mod tests {
         fn into_region(self, vm_addr: u64) -> (Vec<u8>, MemoryRegion, SerializedAccountMetadata) {
             let size = mem::size_of::<AccountInfo>()
                 + mem::size_of::<Pubkey>() * 2
-                + mem::size_of::<RcBox<RefCell<&mut u64>>>()
-                + mem::size_of::<u64>()
-                + mem::size_of::<RcBox<RefCell<&mut [u8]>>>()
+                + mem::size_of::<VmBoxOfRefCell<&mut u64>>()
+                + mem::size_of::<VmBoxOfRefCell<VmSlice<u8>>>()
                 + self.data.len();
             let mut data = vec![0; size];
 
             let vm_addr = vm_addr as usize;
-            let key_addr = vm_addr + mem::size_of::<AccountInfo>();
+            let key_addr = vm_addr + mem::size_of::<VmAccountInfo>();
             let lamports_cell_addr = key_addr + mem::size_of::<Pubkey>();
-            let lamports_addr = lamports_cell_addr + mem::size_of::<RcBox<RefCell<&mut u64>>>();
-            let owner_addr = lamports_addr + mem::size_of::<u64>();
+            let owner_addr = lamports_cell_addr + mem::size_of::<VmBoxOfRefCell<&mut u64>>();
             let data_cell_addr = owner_addr + mem::size_of::<Pubkey>();
-            let data_addr = data_cell_addr + mem::size_of::<RcBox<RefCell<&mut [u8]>>>();
+            let data_addr = data_cell_addr +  mem::size_of::<VmBoxOfRefCell<VmSlice<u8>>>();
 
-            let info = AccountInfo {
-                key: unsafe { (key_addr as *const Pubkey).as_ref() }.unwrap(),
+            let info = VmAccountInfo {
+                key: key_addr as u64,
                 is_signer: self.is_signer,
                 is_writable: self.is_writable,
-                lamports: unsafe {
-                    Rc::from_raw((lamports_cell_addr + RcBox::<&mut u64>::VALUE_OFFSET) as *const _)
-                },
-                data: unsafe {
-                    Rc::from_raw((data_cell_addr + RcBox::<&mut [u8]>::VALUE_OFFSET) as *const _)
-                },
-                owner: unsafe { (owner_addr as *const Pubkey).as_ref() }.unwrap(),
+                lamports: VmNonNull::from_addr(lamports_cell_addr as u64),
+                data: VmNonNull::from_addr(data_cell_addr as u64),
+                owner: owner_addr as u64,
                 executable: self.executable,
                 rent_epoch: self.rent_epoch,
+                phantom: PhantomData,
             };
 
             unsafe {
@@ -2967,11 +2962,7 @@ mod tests {
                 );
                 ptr::write_unaligned(
                     (data.as_mut_ptr() as usize + lamports_cell_addr - vm_addr) as *mut _,
-                    RcBox::new(RefCell::new((lamports_addr as *mut u64).as_mut().unwrap())),
-                );
-                ptr::write_unaligned(
-                    (data.as_mut_ptr() as usize + lamports_addr - vm_addr) as *mut _,
-                    self.lamports,
+                    VmBoxOfRefCell::new(self.lamports),
                 );
                 ptr::write_unaligned(
                     (data.as_mut_ptr() as usize + owner_addr - vm_addr) as *mut _,
@@ -2979,10 +2970,7 @@ mod tests {
                 );
                 ptr::write_unaligned(
                     (data.as_mut_ptr() as usize + data_cell_addr - vm_addr) as *mut _,
-                    RcBox::new(RefCell::new(slice::from_raw_parts_mut(
-                        data_addr as *mut u8,
-                        self.data.len(),
-                    ))),
+                    VmBoxOfRefCell::new(VmSlice::new(data_addr as u64, self.data.len() as u64)),
                 );
                 data[data_addr - vm_addr..].copy_from_slice(self.data);
             }

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -21,6 +21,7 @@ use {
         ALT_BN128_MULTIPLICATION_OUTPUT_LEN, ALT_BN128_PAIRING_ELEMENT_LEN,
         ALT_BN128_PAIRING_OUTPUT_LEN,
     },
+    solana_clock::Epoch,
     solana_cpi::MAX_RETURN_DATA,
     solana_hash::Hash,
     solana_instruction::{error::InstructionError, AccountMeta, ProcessedSiblingInstruction},
@@ -336,7 +337,7 @@ pub struct VmAccountInfo<'a> {
     /// Program that owns this account (in `AccountInfo`: &'a Pubkey)
     pub owner: u64,
     /// The epoch at which this account will next owe rent
-    pub rent_epoch: u64,
+    pub rent_epoch: Epoch,
 
     /// Was the transaction signed by this account's public key?
     pub is_signer: bool,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -21,7 +21,6 @@ use {
         ALT_BN128_MULTIPLICATION_OUTPUT_LEN, ALT_BN128_PAIRING_ELEMENT_LEN,
         ALT_BN128_PAIRING_OUTPUT_LEN,
     },
-    solana_clock::Epoch,
     solana_cpi::MAX_RETURN_DATA,
     solana_hash::Hash,
     solana_instruction::{error::InstructionError, AccountMeta, ProcessedSiblingInstruction},

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -292,6 +292,15 @@ pub struct VmNonNull<T> {
     resource_type: PhantomData<T>,
 }
 
+impl<T> VmNonNull<T> {
+    pub fn from_addr(addr: u64) -> Self {
+        Self {
+            addr,
+            resource_type: PhantomData,
+        }
+    }
+}
+
 #[derive(Clone)]
 #[repr(C)]
 pub struct VmBoxOfRefCell<T> {
@@ -299,6 +308,17 @@ pub struct VmBoxOfRefCell<T> {
     _weak_addr: u64,
     _borrow_flag: u64,
     pub value: T,
+}
+
+impl<T> VmBoxOfRefCell<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            _strong_addr: 0,
+            _weak_addr: 0,
+            _borrow_flag: 0,
+            value,
+        }
+    }
 }
 
 /// Account information, in the virtual address space. Note: Since the addresses are u64,
@@ -316,7 +336,7 @@ pub struct VmAccountInfo<'a> {
     /// Program that owns this account (in `AccountInfo`: &'a Pubkey)
     pub owner: u64,
     /// The epoch at which this account will next owe rent
-    pub rent_epoch: Epoch,
+    pub rent_epoch: u64,
 
     /// Was the transaction signed by this account's public key?
     pub is_signer: bool,
@@ -2183,7 +2203,6 @@ declare_builtin_function!(
 #[allow(clippy::arithmetic_side_effects)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
-    use solana_account_info::AccountInfo;
     #[allow(deprecated)]
     use solana_sysvar::fees::Fees;
     use {
@@ -4469,7 +4488,7 @@ mod tests {
             META_OFFSET + std::mem::size_of::<ProcessedSiblingInstruction>();
         const DATA_OFFSET: usize = PROGRAM_ID_OFFSET + std::mem::size_of::<Pubkey>();
         const ACCOUNTS_OFFSET: usize = DATA_OFFSET + 0x100;
-        const END_OFFSET: usize = ACCOUNTS_OFFSET + std::mem::size_of::<AccountInfo>() * 4;
+        const END_OFFSET: usize = ACCOUNTS_OFFSET + std::mem::size_of::<VmAccountInfo>() * 4;
         let mut memory = [0u8; END_OFFSET];
         let config = Config::default();
         let mut memory_mapping = MemoryMapping::new(

--- a/runtime/src/snapshot_utils/archive_format.rs
+++ b/runtime/src/snapshot_utils/archive_format.rs
@@ -21,10 +21,10 @@ pub const TAR_EXTENSION: &str = "tar";
 /// The different archive formats used for snapshots
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Display)]
 pub enum ArchiveFormat {
-    // TarBzip2, // Unsupproted in svm-rollup
+    // TarBzip2, // Unsupported in svm-rollup
     TarGzip,
-    // TarZstd { config: ZstdConfig }, // Unsupproted in svm-rollup
-    // TarLz4, // Unsupproted in svm-rollup
+    // TarZstd { config: ZstdConfig }, // Unsupported in svm-rollup
+    // TarLz4, // Unsupported in svm-rollup
     Tar,
 }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -914,12 +914,12 @@ pub fn execute(
 
     let archive_format = {
         let archive_format_str = value_t_or_exit!(matches, "snapshot_archive_format", String);
-        let mut archive_format = ArchiveFormat::from_cli_arg(&archive_format_str)
+        let archive_format = ArchiveFormat::from_cli_arg(&archive_format_str)
             .unwrap_or_else(|| panic!("Archive format not recognized: {archive_format_str}"));
-        if let ArchiveFormat::TarZstd { config } = &mut archive_format {
-            config.compression_level =
-                value_t_or_exit!(matches, "snapshot_zstd_compression_level", i32);
-        }
+        // if let ArchiveFormat::TarZstd { config } = &mut archive_format {
+        //     config.compression_level =
+        //         value_t_or_exit!(matches, "snapshot_zstd_compression_level", i32);
+        // }
         archive_format
     };
 


### PR DESCRIPTION
Some new Agave code does a fairly evil creation of an AccountInfo struct that uses a flattened piece of memory for all the parts to now do the same (but also less evilly) for VmAccountInfo.