### PR TITLE
fix: fix ci syntax error, too many ifs

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   check:
-    if: github.repository == 'anza-xyz/agave'
+#    if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -77,7 +77,7 @@ jobs:
           cargo check
 
   test_cli:
-    if: github.repository == 'anza-xyz/agave'
+#    if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -108,7 +108,7 @@ jobs:
           cargo test --manifest-path clients/cli/Cargo.toml
 
   cargo-test-sbf:
-    if: github.repository == 'anza-xyz/agave'
+#    if: github.repository == 'anza-xyz/agave'
     if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
Tiny change.

This is Anza code, but our CI doesn't like it and I guess theirs must be okay with it. Can't have two "if" conditions in the same section. They should've commented out the original if (and did, in another similar code location edited at the same time by the same contributor), which was the intent, judging from their commit and comment.