### PR TITLE
fix: additional fixes to the Agave merge

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -755,9 +755,9 @@ mod tests {
         solana_poh_config::PohConfig,
         solana_pubkey::Pubkey,
         solana_runtime::{
-            bank_forks::BankForks, bank_forks::BankForks,
+            bank_forks::BankForks,
             prioritization_fee_cache::PrioritizationFeeCache,
-            vote_sender_types::ReplayVoteReceiver, vote_sender_types::ReplayVoteReceiver,
+            vote_sender_types::ReplayVoteReceiver,
         },
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -607,8 +607,6 @@ mod tests {
         let working_bank = bank_forks.read().unwrap().working_bank();
         let vote_state = get_vote_state(vote_pubkey, &working_bank);
         let root = vote_state.root_slot.unwrap();
-        let vote_state = get_vote_state(vote_pubkey, &working_bank);
-        let root = vote_state.root_slot.unwrap();
         let ancestors = working_bank.status_cache_ancestors();
         let _ = AggregateCommitmentService::update_commitment_cache(
             &block_commitment_cache,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -427,18 +427,3 @@ mod tests {
         );
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use {super::*, solana_accounts_db::hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE};
-
-    #[test]
-    fn test_max_genesis_archive_unpacked_size_constant() {
-        assert_eq!(
-            MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
-            MAX_GENESIS_ARCHIVE_UNPACKED_SIZE_STR
-                .parse::<u64>()
-                .unwrap()
-        );
-    }
-}

--- a/measure/src/measure.rs
+++ b/measure/src/measure.rs
@@ -82,7 +82,7 @@ impl fmt::Display for Measure {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, std::thread::sleep};
+    use {super::*};
 
     // #[test]
     // fn test_measure() {

--- a/precompiles/src/secp256k1.rs
+++ b/precompiles/src/secp256k1.rs
@@ -133,7 +133,7 @@ pub mod tests {
         crate::test_verify_with_alignment,
         rand0_7::{thread_rng, Rng},
         solana_keccak_hasher as keccak,
-        solana_secp256k1_program::{new_secp256k1_instruction, DATA_START},
+        solana_secp256k1_program::{new_secp256k1_instruction_with_signature, sign_message, DATA_START},
     };
 
     fn test_case(
@@ -306,8 +306,17 @@ pub mod tests {
 
         let secp_privkey = libsecp256k1::SecretKey::random(&mut thread_rng());
         let message_arr = b"hello";
-        let mut instruction = new_secp256k1_instruction(&secp_privkey, message_arr);
-        let feature_set = FeatureSet::all_enabled();
+        let secp_pubkey = libsecp256k1::PublicKey::from_secret_key(&secp_privkey);
+        let eth_address =
+            eth_address_from_pubkey(&secp_pubkey.serialize()[1..].try_into().unwrap());
+        let (signature, recovery_id) =
+            sign_message(&secp_privkey.serialize(), message_arr).unwrap();
+        let mut instruction = new_secp256k1_instruction_with_signature(
+            message_arr,
+            &signature,
+            recovery_id,
+            &eth_address,
+        );        let feature_set = FeatureSet::all_enabled();
         assert!(test_verify_with_alignment(
             verify,
             &instruction.data,

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -21,6 +21,7 @@ use {
         ALT_BN128_MULTIPLICATION_OUTPUT_LEN, ALT_BN128_PAIRING_ELEMENT_LEN,
         ALT_BN128_PAIRING_OUTPUT_LEN,
     },
+    solana_clock::Epoch,
     solana_cpi::MAX_RETURN_DATA,
     solana_hash::Hash,
     solana_instruction::{error::InstructionError, AccountMeta, ProcessedSiblingInstruction},

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10362,8 +10362,19 @@ fn test_call_precomiled_program() {
         }
     };
     let message_arr = b"hello";
-    let instruction =
-        solana_secp256k1_program::new_secp256k1_instruction(&secp_privkey, message_arr);
+    let pubkey = libsecp256k1::PublicKey::from_secret_key(&secp_privkey);
+    let eth_address = solana_secp256k1_program::eth_address_from_pubkey(
+        &pubkey.serialize()[1..].try_into().unwrap(),
+    );
+    let (signature, recovery_id) =
+        solana_secp256k1_program::sign_message(&secp_privkey.serialize(), &message_arr[..])
+            .unwrap();
+    let instruction = solana_secp256k1_program::new_secp256k1_instruction_with_signature(
+        &message_arr[..],
+        &signature,
+        recovery_id,
+        &eth_address,
+    );
     let tx = Transaction::new_signed_with_payer(
         &[instruction],
         Some(&mint_keypair.pubkey()),


### PR DESCRIPTION
Updates mostly to test code, either for the change of new_secp256k1_instruction to new_secp256k1_instruction_with_signature, or some duplicated bad-merge code.