### PR TITLE
Fix typo

### DIFF
--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "solana-precompiles"
+name = "agave-precompiles"
 description = "Solana precompiled programs."
 documentation = "https://docs.rs/agave-precompiles"
 version = "2.2.2"


### PR DESCRIPTION
I believe this was a typo from https://github.com/nitro-svm/agave/commit/fe9597618e1380c9e3e471addac9d3583d77f35f, and the naming inconsistency is causing some build issues because the root Cargo.toml expects `agave-precompiles` instead of `solana-precompiles`.